### PR TITLE
Fix curl to follow redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 Download `ansi` and put it somewhere in your path.  Make sure that it is executable (`chmod a+x ansi` works well).  Bash will need to be present, but it is often installed by default.  No external commands are used; this only uses bash's built-in features.
 
     # Download
-    curl -O https://git.io/ansi
+    curl -OL git.io/ansi
 
     # Make executable
     chmod 755 ansi


### PR DESCRIPTION
In this case `curl` needs the `-L` flag to follow the redirection from the URL shortener, and correctly download the script. (Another alternative would be to use `wget git.io/ansi`)

At the same time the 'http://' part is not required, leaving it out simplifies the command.