### PR TITLE
Fix incorrect exit status when sourcing the script

### DIFF
--- a/ansi
+++ b/ansi
@@ -669,4 +669,4 @@ ansi() {
 
 
 # Run if not sourced
-[[ "$0" == "${BASH_SOURCE[0]}" ]] && ansi "$@"
+if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then ansi "$@"; fi


### PR DESCRIPTION
A bug, caused by using the short form test condition as the last script statement, that caused the script using the test exit status as the exit status for the whole script. So that when the script is sourced, the exit status of the source command was 1, instead of 0.

Using `if` way the test exit status doesn't leak.