### PR TITLE
enable to override terminal detection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Download `ansi` and put it somewhere in your path.  Make sure that it is executa
     sudo mv ansi /usr/local/bin/
 
 Not all features will work with all terminals.  Your terminal determines if particular codes work.
+You can override the terminal detection logic and force `ansi` to output color codes with the environment variable `ANSI_FORCE_SUPPORT` set to any non-empty value.
 
 
 ### [BPM] Installation

--- a/ansi
+++ b/ansi
@@ -427,6 +427,13 @@ ansi::invisible() {
 }
 
 ansi::isAnsiSupported() {
+    # Optionally override detection logic
+    # to support post processors that interpret color codes _after_ output is generated.
+    # Use environment variable "ANSI_FORCE_SUPPORT=<anything>" to enable the override.
+    if [[ -n "${ANSI_FORCE_SUPPORT-}" ]]; then
+        return 0
+    fi
+
     if hash tput &> /dev/null; then
         if [[ "$(tput colors)" -lt 8 ]]; then
             return 1


### PR DESCRIPTION
This allows to generate raw output that has the color codes even
if the terminal does not support color. The raw output can then
be passed through a post-processor that _does_ interpret the codes.

One example is Jenkins with its AnsiColor plugin.