### PR TITLE
avoid unset variable error

### DIFF
--- a/ansi
+++ b/ansi
@@ -1610,7 +1610,7 @@ ansi() {
         fi
 
         if $restoreText; then
-            m="$m10$m22$m23$m24$m25$m27$m28$m29$m$m39$m49$m54$m55$m65"
+            m="$m10$m22$m23$m24$m25$m27$m28$m29$m39$m49$m54$m55$m65"
             printf '%s%sm' "$ANSI_CSI" "${m%;}"
         fi
     fi


### PR DESCRIPTION
When using Bash `set -u` to treat unset variables as an error,
`ansi` fails with:

    line 1613: m: unbound variable

There are two ways to resolve this:

* First, it would be trivial to add `m=` like the other `m*` vars.
* However, `$m` is never referenced outside of this conditional, so
  it seems more correct to just fix the usage as done in this commit.